### PR TITLE
BLE stability fixes and Studio improvements

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -9,9 +9,4 @@ include:
     cmake-args: -DCONFIG_ZMK_STUDIO=y
     artifact-name: ergonaut_one_left_studio
   - board: xiao_ble//zmk
-    shield: ergonaut_one_right
-    snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
-    artifact-name: ergonaut_one_right_studio
-  - board: xiao_ble//zmk
     shield: settings_reset

--- a/config/ergonaut_one.conf
+++ b/config/ergonaut_one.conf
@@ -21,11 +21,3 @@ CONFIG_BT_GATT_ENFORCE_SUBSCRIPTION=n
 
 # Disable 2M PHY — fixes pairing/reconnect loops with some Windows BT adapters
 CONFIG_BT_CTLR_PHY_2M=n
-
-# Tighter connection intervals (1.25 ms units): 6=7.5ms min, 12=15ms max
-# Reduces the window where a dropped connection causes stuck keys
-# Revert if disconnects increase (some PC BT adapters ignore these anyway)
-CONFIG_BT_PERIPHERAL_PREF_MIN_INT=6
-CONFIG_BT_PERIPHERAL_PREF_MAX_INT=12
-CONFIG_BT_PERIPHERAL_PREF_LATENCY=0
-CONFIG_BT_PERIPHERAL_PREF_TIMEOUT=400


### PR DESCRIPTION
## Summary

- Remove right half studio build — ZMK Studio only works via the central (left) half
- Remove aggressive BLE connection intervals that caused pairing failures on some PC Bluetooth adapters

## Context

Previous commits on master already include:
- `CONFIG_BT_GATT_ENFORCE_SUBSCRIPTION=n` — fixes stuck keys after BLE reconnect
- `CONFIG_BT_CTLR_PHY_2M=n` — fixes pairing/reconnect loops with Windows BT adapters
- ZMK pinned to v0.3.0 in west.yml for build stability

## Test plan

- [ ] Flash `ergonaut_one_left_studio.uf2` to left half, `ergonaut_one_right.uf2` to right half
- [ ] Verify BLE pairing works (remove device from PC, re-pair fresh)
- [ ] Verify no stuck keys after BLE reconnect
- [ ] Verify ZMK Studio connects via USB to left half only

🤖 Generated with [Claude Code](https://claude.com/claude-code)